### PR TITLE
fix improper cast 16-bit to 32-bit integer handling

### DIFF
--- a/query_basics.go
+++ b/query_basics.go
@@ -103,7 +103,7 @@ func (m *TX) Deserialize(bytes []byte) {
 	copy(m.Pblockhash[:], bytes[58:90])
 	copy(m.Weight[:], bytes[90:122])
 	copy(m.Len[:], bytes[122:124])
-	len_buffer := binary.LittleEndian.Uint16(m.Len[:])
+	len_buffer := int(binary.LittleEndian.Uint16(m.Len[:]))
 	m.Buffer = make([]byte, len_buffer)
 	copy(m.Buffer[:], bytes[124:124+len_buffer])
 	copy(m.Crc16[:], bytes[124+len_buffer:124+len_buffer+2])
@@ -233,8 +233,8 @@ func (m *SocketData) recvTX() error {
 		return fmt.Errorf("received less than 124 bytes")
 	}
 	// Now read the rest of the bytes
-	length := binary.LittleEndian.Uint16(buf[122:124]) + 4
-	buf = append(buf, make([]byte, int(length))...)
+	length := int(binary.LittleEndian.Uint16(buf[122:124])) + 4
+	buf = append(buf, make([]byte, length)...)
 	_, err = io.ReadFull(m.Conn, buf[TX_UP_TO_LEN:])
 	if err != nil {
 		fmt.Println("Error reading:", err)
@@ -292,7 +292,7 @@ func (m *SocketData) recvFile() ([]byte, error) {
 		}
 
 		// Bytes received in len
-		len := binary.LittleEndian.Uint16(m.recv_tx.Len[:])
+		len := int(binary.LittleEndian.Uint16(m.recv_tx.Len[:]))
 
 		// Get the bytes
 		file = append(file, m.recv_tx.serialize()[124:124+len]...)


### PR DESCRIPTION
Go doesn't seem to do integer promotion. So, it seems, the 16-bit length integer derived from the byte array seems to be used as the word size for calculations it's a part of. This causes overflow in some cases. I just manually cast the 16-bit values to int BEFORE assigning them to the length variable.